### PR TITLE
Feature/create service get planet

### DIFF
--- a/src/controllers/planets.ts
+++ b/src/controllers/planets.ts
@@ -4,12 +4,12 @@ import { Request, Response } from 'express'
 const prisma = new PrismaClient()
 
 export const getFindOne = async (req: Request, res: Response) => {
-	const { id } = req.params
+	const { name } = req.params
 
 	const planet = await prisma.planet.findFirst({
 		where: {
 			name: {
-				startsWith: id,
+				startsWith: name,
 				mode: 'insensitive',
 			},
 		},
@@ -20,7 +20,7 @@ export const getFindOne = async (req: Request, res: Response) => {
 			structure: true,
 		},
 	})
-	if (!planet) return res.status(404).send(`Not found this planet: ${id}`)
+	if (!planet) return res.status(404).send(`Not found this planet: ${name}`)
 
 	return res.json(planet)
 }

--- a/src/controllers/planets.ts
+++ b/src/controllers/planets.ts
@@ -1,25 +1,10 @@
-import { PrismaClient } from '@prisma/client'
 import { Request, Response } from 'express'
-
-const prisma = new PrismaClient()
+import planetService from 'services/planets'
 
 export const getFindOne = async (req: Request, res: Response) => {
 	const { name } = req.params
+	const planet = await planetService.getPlanet(name)
 
-	const planet = await prisma.planet.findFirst({
-		where: {
-			name: {
-				startsWith: name,
-				mode: 'insensitive',
-			},
-		},
-		include: {
-			geology: true,
-			images: true,
-			overview: true,
-			structure: true,
-		},
-	})
 	if (!planet) return res.status(404).send(`Not found this planet: ${name}`)
 
 	return res.json(planet)

--- a/src/routes/planets.ts
+++ b/src/routes/planets.ts
@@ -3,6 +3,6 @@ import { getFindOne } from '@controllers/planets'
 
 const router = Router()
 
-router.get('/:id', getFindOne)
+router.get('/:name', getFindOne)
 
 export default router

--- a/src/services/planets.ts
+++ b/src/services/planets.ts
@@ -1,0 +1,26 @@
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+const getPlanet = async (name: string) => {
+	const planetResponse = await prisma.planet.findFirst({
+		where: {
+			name: {
+				startsWith: name,
+				mode: 'insensitive',
+			},
+		},
+		include: {
+			geology: true,
+			images: true,
+			overview: true,
+			structure: true,
+		},
+	})
+
+	return planetResponse
+}
+
+export default {
+	getPlanet,
+}


### PR DESCRIPTION
- Se renombra el parámetro **:id** por **:name**, esto debido a que ya no se está pasando un ID sino un nombre para obtener la respuesta de un planeta.

- Se crea un servicio para poder obtener la respuesta de la base de datos, que este separado del controlador, de esta manera en un futuro cuando se deje de usar prisma la migración se hará más sencilla.